### PR TITLE
Renamed es-cleanup.py to es_cleanup.py

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,5 @@
 data "http" "src" {
-  url = "https://raw.githubusercontent.com/cloudreach/aws-lambda-es-cleanup/master/es-cleanup.py"
+  url = "https://raw.githubusercontent.com/cloudreach/aws-lambda-es-cleanup/master/es_cleanup.py"
 }
 
 resource "local_file" "src_local" {


### PR DESCRIPTION
caused by https://github.com/cloudreach/aws-lambda-es-cleanup/commit/a298b34809faa13bf48076f28ddd49bce639dffd