### PR TITLE
Update archive creation to remove temporary local file.

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -2,19 +2,15 @@ data "http" "src" {
   url = "https://raw.githubusercontent.com/cloudreach/aws-lambda-es-cleanup/master/es_cleanup.py"
 }
 
-resource "local_file" "src_local" {
-  content  = "${data.http.src.body}"
-  filename = "${path.module}/es-cleanup.py"
-}
-
-
 data "archive_file" "es_cleanup_lambda" {
-  type        = "zip"
-  source_file = "${path.module}/es-cleanup.py"
+  type = "zip"
+
+  source {
+    content  = "${data.http.src.body}"
+    filename = "es-cleanup.py"
+  }
+
   output_path = "${path.module}/es-cleanup.zip"
-  depends_on = [
-    local_file.src_local,
-  ]
 }
 
 locals {


### PR DESCRIPTION
Since updating to terraform 0.13 we've been receiving the following error:

```
Error: error archiving file: could not archive missing file: .terraform/modules/es-cleanup/es-cleanup.py

  on .terraform/modules/es-cleanup/lambda.tf line 11, in data "archive_file" "es_cleanup_lambda":
  11: data "archive_file" "es_cleanup_lambda" {
```

This change builds the archive file directly from the downloaded file without a local file instance: https://registry.terraform.io/providers/hashicorp/archive/1.3.0/docs/data-sources/archive_file